### PR TITLE
feat: scenario enhancements - story, math, role fit, and accuracy

### DIFF
--- a/src/app/game/[lobbyId]/page.tsx
+++ b/src/app/game/[lobbyId]/page.tsx
@@ -358,8 +358,14 @@ export default function GamePage() {
 
         {/* Chapter image */}
         {scenario.image && (
-          <div className="w-full h-32 sm:h-40 relative mb-4 rounded-lg overflow-hidden bg-[#1e293b] game-chapter-image flex items-center justify-center">
-            <Image src={scenario.image} alt={scenario.title} fill sizes="(max-width: 768px) 100vw, 56rem" style={{ objectFit: 'contain' }} priority />
+          <div className="w-full h-32 sm:h-40 relative mb-4 rounded-lg overflow-hidden game-chapter-image">
+            <Image src={scenario.image} alt={scenario.title} fill sizes="(max-width: 768px) 100vw, 56rem" style={{ objectFit: 'cover' }} priority />
+          </div>
+        )}
+
+        {scenario.storyContext && (
+          <div className="bg-[#0f172a] border border-[#1e293b] rounded-lg p-4 mb-4 text-center">
+            <p className="text-sm text-[#cbd5e1] italic leading-relaxed">{scenario.storyContext}</p>
           </div>
         )}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,7 +83,7 @@ html, body {
 }
 
 [data-device="desktop"] .game-chapter-image img {
-  object-fit: contain;
+  object-fit: cover;
 }
 
 [data-device="desktop"] .game-header {
@@ -135,5 +135,29 @@ html, body {
 
 [data-device="desktop"] .drag-drop-zone-full {
   grid-column: 1 / -1;
+}
+
+/* Themed scrollbar — used on leaderboard/results tables */
+.themed-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #334155 transparent;
+}
+
+.themed-scroll::-webkit-scrollbar {
+  width: 4px;
+}
+
+.themed-scroll::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 9999px;
+}
+
+.themed-scroll::-webkit-scrollbar-thumb {
+  background-color: #334155;
+  border-radius: 9999px;
+}
+
+.themed-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #FF6600;
 }
 

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -21,8 +21,8 @@ function LeaderboardContent() {
     async function load() {
       try {
         const [tSnap, iSnap] = await Promise.all([
-          getDocs(query(collection(db, 'teams'), orderBy('totalScore', 'desc'), limit(50))),
-          getDocs(query(collection(db, 'events', 'global', 'scores'), orderBy('score', 'desc'), limit(50))),
+          getDocs(query(collection(db, 'teams'), orderBy('totalScore', 'desc'), limit(20))),
+          getDocs(query(collection(db, 'events', 'global', 'scores'), orderBy('score', 'desc'), limit(20))),
         ]);
         setTeams(tSnap.docs.map(d => {
           const dd = d.data();
@@ -74,29 +74,31 @@ function LeaderboardContent() {
           <p className="text-center text-[#94a3b8] mt-16">No team scores yet.<br />Play with a team name to appear here.</p>
         ) : (
           <div className="bg-[#1e293b] rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-[#334155]">
-                  <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
-                  <th className="text-left p-3 text-[#94a3b8]">Team</th>
-                  <th className="text-center p-3 text-[#94a3b8] hidden sm:table-cell">Players</th>
-                  <th className="text-right p-3 text-[#94a3b8]">Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {teams.map((t, i) => (
-                  <tr key={t.teamName} className="border-b border-[#334155]/50 hover:bg-[#334155]/30 transition">
-                    <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
-                    <td className="p-3">
-                      <p className="text-[#e2e8f0] font-semibold">{t.teamName}</p>
-                      <p className="text-[#94a3b8] text-xs">avg {t.avgScore} / player</p>
-                    </td>
-                    <td className="p-3 text-center text-[#94a3b8] hidden sm:table-cell">{t.playerCount}</td>
-                    <td className="p-3 text-right text-[#FF6600] font-bold text-base">{t.totalScore}</td>
+            <div className="overflow-y-auto max-h-96 themed-scroll">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-[#1e293b] z-10">
+                  <tr className="border-b border-[#334155]">
+                    <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
+                    <th className="text-left p-3 text-[#94a3b8]">Team</th>
+                    <th className="text-center p-3 text-[#94a3b8] hidden sm:table-cell">Players</th>
+                    <th className="text-right p-3 text-[#94a3b8]">Total</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {teams.map((t, i) => (
+                    <tr key={t.teamName} className="border-b border-[#334155]/50 hover:bg-[#334155]/30 transition">
+                      <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
+                      <td className="p-3">
+                        <p className="text-[#e2e8f0] font-semibold">{t.teamName}</p>
+                        <p className="text-[#94a3b8] text-xs">avg {t.avgScore} / player</p>
+                      </td>
+                      <td className="p-3 text-center text-[#94a3b8] hidden sm:table-cell">{t.playerCount}</td>
+                      <td className="p-3 text-right text-[#FF6600] font-bold text-base">{t.totalScore}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )
       ) : (
@@ -104,28 +106,30 @@ function LeaderboardContent() {
           <p className="text-center text-[#94a3b8] mt-16">No individual scores yet.</p>
         ) : (
           <div className="bg-[#1e293b] rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-[#334155]">
-                  <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
-                  <th className="text-left p-3 text-[#94a3b8]">Player</th>
-                  <th className="text-right p-3 text-[#94a3b8] hidden sm:table-cell">Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {individuals.map((e, i) => (
-                  <tr key={e.uid} className="border-b border-[#334155]/50 hover:bg-[#334155]/30 transition">
-                    <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
-                    <td className="p-3">
-                      <p className="text-[#e2e8f0] font-medium">{e.name}</p>
-                      {e.teamName && <p className="text-[#94a3b8] text-xs">{e.teamName}</p>}
-                      <p className="text-[#94a3b8] text-xs">{e.vocation}</p>
-                    </td>
-                    <td className="p-3 text-right text-[#FF6600] font-bold hidden sm:table-cell">{e.score}</td>
+            <div className="overflow-y-auto max-h-96 themed-scroll">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-[#1e293b] z-10">
+                  <tr className="border-b border-[#334155]">
+                    <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
+                    <th className="text-left p-3 text-[#94a3b8]">Player</th>
+                    <th className="text-right p-3 text-[#94a3b8] hidden sm:table-cell">Score</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {individuals.map((e, i) => (
+                    <tr key={e.uid} className="border-b border-[#334155]/50 hover:bg-[#334155]/30 transition">
+                      <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
+                      <td className="p-3">
+                        <p className="text-[#e2e8f0] font-medium">{e.name}</p>
+                        {e.teamName && <p className="text-[#94a3b8] text-xs">{e.teamName}</p>}
+                        <p className="text-[#94a3b8] text-xs">{e.vocation}</p>
+                      </td>
+                      <td className="p-3 text-right text-[#FF6600] font-bold hidden sm:table-cell">{e.score}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )
       )}

--- a/src/app/results/[lobbyId]/page.tsx
+++ b/src/app/results/[lobbyId]/page.tsx
@@ -358,29 +358,31 @@ export default function ResultsPage() {
               <p className="text-center text-[#94a3b8] text-sm py-4">No team scores yet — play with a team name to appear here.</p>
             ) : (
               <div className="bg-[#1e293b] rounded-xl overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-[#334155]">
-                      <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
-                      <th className="text-left p-3 text-[#94a3b8]">Team</th>
-                      <th className="text-center p-3 text-[#94a3b8] hidden sm:table-cell">Players</th>
-                      <th className="text-right p-3 text-[#94a3b8]">Total Score</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {teamLeaderboard.map((t, i) => (
-                      <tr key={t.teamName} className={`border-b border-[#334155]/50 ${t.teamName === myTeamName ? 'bg-[#FF6600]/10' : ''}`}>
-                        <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
-                        <td className="p-3">
-                          <p className="text-[#e2e8f0] font-semibold max-w-[140px] truncate">{t.teamName}</p>
-                          <p className="text-[#94a3b8] text-xs">avg {t.avgScore} / player</p>
-                        </td>
-                        <td className="p-3 text-center text-[#94a3b8] hidden sm:table-cell">{t.playerCount}</td>
-                        <td className="p-3 text-right text-[#FF6600] font-bold text-base">{t.totalScore}</td>
+                <div className="overflow-y-auto max-h-96 themed-scroll">
+                  <table className="w-full text-sm">
+                    <thead className="sticky top-0 bg-[#1e293b] z-10">
+                      <tr className="border-b border-[#334155]">
+                        <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
+                        <th className="text-left p-3 text-[#94a3b8]">Team</th>
+                        <th className="text-center p-3 text-[#94a3b8] hidden sm:table-cell">Players</th>
+                        <th className="text-right p-3 text-[#94a3b8]">Total Score</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {teamLeaderboard.map((t, i) => (
+                        <tr key={t.teamName} className={`border-b border-[#334155]/50 ${t.teamName === myTeamName ? 'bg-[#FF6600]/10' : ''}`}>
+                          <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
+                          <td className="p-3">
+                            <p className="text-[#e2e8f0] font-semibold max-w-[140px] truncate">{t.teamName}</p>
+                            <p className="text-[#94a3b8] text-xs">avg {t.avgScore} / player</p>
+                          </td>
+                          <td className="p-3 text-center text-[#94a3b8] hidden sm:table-cell">{t.playerCount}</td>
+                          <td className="p-3 text-right text-[#FF6600] font-bold text-base">{t.totalScore}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             )
           )}
@@ -390,31 +392,33 @@ export default function ResultsPage() {
               <p className="text-center text-[#94a3b8] text-sm py-4">No individual scores yet.</p>
             ) : (
               <div className="bg-[#1e293b] rounded-xl overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-[#334155]">
-                      <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
-                      <th className="text-left p-3 text-[#94a3b8]">Player</th>
-                      <th className="text-right p-3 text-[#94a3b8] hidden sm:table-cell">Score</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {individualLeaderboard.map((e, i) => (
-                      <tr key={e.uid} className={`border-b border-[#334155]/50 ${e.uid === user.uid ? 'bg-[#FF6600]/10' : ''}`}>
-                        <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
-                        <td className="p-3">
-                          <p className="text-[#e2e8f0] font-medium">
-                            {e.name}
-                            {e.uid === user.uid && <span className="text-[#FF6600] text-xs ml-1">(you)</span>}
-                          </p>
-                          {e.teamName && <p className="text-[#94a3b8] text-xs">{e.teamName}</p>}
-                          <p className="text-[#94a3b8] text-xs">{e.vocation}</p>
-                        </td>
-                        <td className="p-3 text-right text-[#FF6600] font-bold hidden sm:table-cell">{e.score}</td>
+                <div className="overflow-y-auto max-h-96 themed-scroll">
+                  <table className="w-full text-sm">
+                    <thead className="sticky top-0 bg-[#1e293b] z-10">
+                      <tr className="border-b border-[#334155]">
+                        <th className="text-left p-3 text-[#94a3b8] w-8">#</th>
+                        <th className="text-left p-3 text-[#94a3b8]">Player</th>
+                        <th className="text-right p-3 text-[#94a3b8] hidden sm:table-cell">Score</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {individualLeaderboard.map((e, i) => (
+                        <tr key={e.uid} className={`border-b border-[#334155]/50 ${e.uid === user.uid ? 'bg-[#FF6600]/10' : ''}`}>
+                          <td className={`p-3 font-bold text-base ${medalColour(i)}`}>{i + 1}</td>
+                          <td className="p-3">
+                            <p className="text-[#e2e8f0] font-medium">
+                              {e.name}
+                              {e.uid === user.uid && <span className="text-[#FF6600] text-xs ml-1">(you)</span>}
+                            </p>
+                            {e.teamName && <p className="text-[#94a3b8] text-xs">{e.teamName}</p>}
+                            <p className="text-[#94a3b8] text-xs">{e.vocation}</p>
+                          </td>
+                          <td className="p-3 text-right text-[#FF6600] font-bold hidden sm:table-cell">{e.score}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             )
           )}

--- a/src/scenarios/arc1-ch1.json
+++ b/src/scenarios/arc1-ch1.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc1-ch1.svg",
   "arc": 0,
   "chapter": 0,
+  "storyContext": "Three weeks before NDP and your phone buzzes at 2am. The committee just approved a last-minute parade segment, and they want a companion app feature ready for 40,000 attendees. Your team lead forwards the message with one line: \"We ship this or we don't ship at all.\" The office lights are still on at DSTA. Nobody's going home tonight.",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",
@@ -42,7 +43,7 @@
       "type": "binary-choice",
       "title": "Pick a Hosting Plan",
       "instruction": "The NDP app feature needs a cloud hosting plan that can handle massive traffic on the actual day but not waste money sitting idle the other 364 days. What's your approach?",
-      "hint": "Your budget has to cover 364 days of waiting plus 1 day of peak load. What matters most — upfront cost, ongoing costs, or reliability?",
+      "hint": "Your budget has to cover 364 days of waiting plus 1 day of peak load. What matters most: upfront cost, ongoing costs, or reliability?",
       "options": [
         {
           "id": "serverless",

--- a/src/scenarios/arc1-ch2.json
+++ b/src/scenarios/arc1-ch2.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc1-ch2.svg",
   "arc": 0,
   "chapter": 1,
+  "storyContext": "The combined rehearsal is in full swing. Forty thousand people in the stands just opened the NDP app at the same time, and your monitoring dashboard has turned completely red. The production manager is on the radio asking why the float overlay keeps crashing. You have until the fireworks segment to fix this, or the committee pulls the feature for the actual show.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",
@@ -20,7 +21,7 @@
         {
           "id": "kill-features",
           "label": "Turn off the camera overlay and serve a simple text-only version. The app becomes instantly fast but loses its wow factor for this rehearsal.",
-          "axisImpact": { "Stability": 1, "Speed": 0.5, "Innovation": -0.8 }
+          "axisImpact": { "Stability": 1, "Speed": 0.5, "Innovation": -0.5 }
         },
         {
           "id": "optimize-queries",
@@ -35,11 +36,24 @@
       ]
     },
     "data-scientist": {
+      "type": "numeric-input",
+      "title": "Estimate the Server Shortfall",
+      "instruction": "The app is getting hit harder every few minutes. Each server can handle about 5,000 users at once. Based on the user count over the last 4 time windows (in thousands), estimate the total number of servers you need to handle the peak.",
+      "hint": "Look at how fast the user count is climbing. Project where it peaks, then divide by server capacity.",
+      "chartData": [4, 12, 28, 40],
+      "expected": 11,
+      "tolerance": 3,
+      "axisImpact": {
+        "Performance-First": 1,
+        "Cost-Conscious": 0.5
+      }
+    },
+    "cloud-engineer": {
       "type": "drag-drop",
       "variant": "order",
-      "title": "Find Out What's Breaking",
-      "instruction": "The monitoring screen is showing warnings everywhere. You need to run a proper investigation to figure out what's actually failing and why. Put these steps in the right order.",
-      "hint": "Always look at the big picture first before zooming in. Start with what's already visible before digging for hidden clues.",
+      "title": "Investigate the Infrastructure Failure",
+      "instruction": "The monitoring screen is lit up with warnings. As the infrastructure lead, you need to run a systematic investigation to figure out which part of the stack is actually failing and why. Put these diagnostic steps in the right order.",
+      "hint": "Always look at the big picture first before zooming in. Start with what is already visible before digging for hidden clues.",
       "items": [
         { "id": "check-metrics", "label": "Pull up the live dashboard showing server load, memory usage, and network traffic" },
         { "id": "identify-bottleneck", "label": "Match the spike timing to specific parts of the app to pinpoint where things are breaking" },
@@ -51,19 +65,6 @@
       "axisImpact": {
         "Precision": 1,
         "Speed": 0.5
-      }
-    },
-    "cloud-engineer": {
-      "type": "numeric-input",
-      "title": "Scale Up the Servers",
-      "instruction": "The setup currently has 4 servers, each comfortably handling about 10,000 users. But 40,000 users just showed up and more are joining. Based on the user count over the last 4 time windows (in thousands), how many servers do you need to spin up RIGHT NOW to handle the peak?",
-      "hint": "You know how many users each server can handle. What's the peak load from the chart?",
-      "chartData": [4, 12, 28, 40],
-      "expected": 8,
-      "tolerance": 3,
-      "axisImpact": {
-        "Performance-First": 1,
-        "Cost-Conscious": 0.5
       }
     }
   }

--- a/src/scenarios/arc1-ch3.json
+++ b/src/scenarios/arc1-ch3.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc1-ch3.svg",
   "arc": 0,
   "chapter": 2,
+  "storyContext": "It's 5:47am on NDP morning. You're half asleep at your desk when the Slack channel explodes. A contractor ran a cleanup script against the wrong database, and the production data is gone. The last backup is 6 hours old. Gates open at 9am. Three hours to bring it all back, with 40,000 people expecting a working app when they walk in.",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",
@@ -29,7 +30,7 @@
       "type": "binary-choice",
       "title": "Recover the Lost Data",
       "instruction": "The wiped database included 6 hours of user activity that marketing needs for their NDP social media campaign. The raw records still exist in a separate system but they're messy and unprocessed. What's your plan?",
-      "hint": "Something useful delivered in time beats something perfect delivered too late — but think about whether the data is even still relevant.",
+      "hint": "Something useful delivered in time beats something perfect delivered too late. But think about whether the data is even still relevant.",
       "options": [
         {
           "id": "rebuild-full",

--- a/src/scenarios/arc1-ch4.json
+++ b/src/scenarios/arc1-ch4.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc1-ch4.svg",
   "arc": 0,
   "chapter": 3,
+  "storyContext": "The national anthem just finished and the stands are packed. Millions more are watching the livestream from home. Then your phone vibrates: the video pipeline is choking. Frames are dropping, the buffer wheel is spinning, and social media is already full of complaints. The fireworks finale is in 20 minutes. The whole nation is counting on your team.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",
@@ -37,11 +38,11 @@
     "data-scientist": {
       "type": "numeric-input",
       "title": "Predict Viewer Drop-off",
-      "instruction": "Viewers are leaving the livestream because of the buffering. Based on the viewer count trend over the last 4 minutes (in thousands), predict how many viewers (in thousands) will still be watching in 5 minutes if nothing is done. This tells the team how urgently they need to act.",
-      "hint": "Viewers are leaving because the stream keeps freezing. How many leave every minute? If that continues, what's the damage in 5 minutes?",
+      "instruction": "Viewers are abandoning the livestream because of the buffering. Based on the viewer count over the last 4 minutes (in thousands), predict the viewer count (in thousands) at the next minute mark if nothing is done. This tells the team how urgently they need to act.",
+      "hint": "Viewers are leaving because the stream keeps freezing. How much is the count dropping each minute? Apply that trend to get the next value.",
       "chartData": [850, 780, 690, 610],
-      "expected": 480,
-      "tolerance": 80,
+      "expected": 530,
+      "tolerance": 60,
       "axisImpact": {
         "Precision": 1,
         "Speed": 0.5

--- a/src/scenarios/arc2-ch1.json
+++ b/src/scenarios/arc2-ch1.json
@@ -5,12 +5,13 @@
   "image": "/chapters/arc2-ch1.svg",
   "arc": 1,
   "chapter": 0,
+  "storyContext": "Your team just got seconded to a classified project. In 30 days, the SAF kicks off Exercise Northstar, the biggest multi-domain exercise this decade. Command wants a single screen that shows every unit's position, supply levels, and comms status in real time. The catch: it has to work in a jungle training area with barely any mobile signal. You have one month to build something that generals will trust with live operational decisions.",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",
       "variant": "layout",
-      "title": "Design the Command Screen",
-      "instruction": "The commanders want a single screen that shows everything: where units are, what supplies they have, and whether comms are working. Drag each piece of information to the right spot on the screen. Slot 1 is the main display, Slots 2 and 3 are side panels, and Slot 4 is the status bar at the bottom.",
+      "title": "Architect the Dashboard Components",
+      "instruction": "The commanders need a single-screen dashboard. You are designing which data component feeds into which rendering slot based on resource intensity and real-time data dependencies. The main display needs the most resource-intensive component. Side panels handle supporting feeds. The status bar shows lightweight system health. Drag each component to the right slot.",
       "hint": "The most important information (the one commanders look at every few seconds) should take up the most space.",
       "items": [
         { "id": "live-map", "label": "Live Map with Unit Positions" },

--- a/src/scenarios/arc2-ch2.json
+++ b/src/scenarios/arc2-ch2.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc2-ch2.svg",
   "arc": 1,
   "chapter": 1,
+  "storyContext": "One week to go and the stress test results just came in. The command screen crashes the moment 500 users connect. The exercise will have 3,000. Your team lead slides the test report across the table and says, \"The generals demo this on Thursday. Fix it or we explain to a two-star why his screen went blank.\" Seven days. No extensions.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",

--- a/src/scenarios/arc2-ch3.json
+++ b/src/scenarios/arc2-ch3.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc2-ch3.svg",
   "arc": 1,
   "chapter": 2,
+  "storyContext": "The exercise is live and 3,000 personnel are in the field. Then the radio crackles: \"Command, why does my screen show Alpha Company at grid reference from twenty minutes ago? They moved to the ridge line ages ago.\" Field commanders are making decisions based on stale positions. In a real operation, that kind of lag gets people hurt.",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",

--- a/src/scenarios/arc2-ch4.json
+++ b/src/scenarios/arc2-ch4.json
@@ -5,11 +5,12 @@
   "image": "/chapters/arc2-ch4.svg",
   "arc": 1,
   "chapter": 3,
+  "storyContext": "Exercise Northstar is over. Vehicles are rolling back to camp and everyone is exhausted, but the work is not done. The Chief of Army wants a data-driven report on unit readiness, decision speed, and logistics efficiency within two weeks. The findings will shape how the SAF trains for the next five years. Your team has mountains of GPS tracks, supply logs, radio transcripts, and decision timestamps. Time to turn raw data into answers that matter.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",
       "title": "Build the Review Tool",
-      "instruction": "The generals want an interactive tool that lets them replay the entire exercise — scrolling through a timeline like a video player to see how decisions played out with data on screen. How do you build it?",
+      "instruction": "The generals want an interactive tool that lets them replay the entire exercise, scrolling through a timeline like a video player to see how decisions played out with data on screen. How do you build it?",
       "hint": "Think about the trade-off between giving commanders something rich and interactive versus something simpler that can be shared widely and is ready sooner.",
       "options": [
         {
@@ -56,10 +57,10 @@
     "cloud-engineer": {
       "type": "numeric-input",
       "title": "Work Out How Much Storage You Need",
-      "instruction": "The exercise data needs to be archived for future training analysis. Based on how much data was generated each day (in terabytes) over the last 4 days of the exercise, estimate the total storage (in terabytes) needed to archive the full 14-day exercise — including an extra 30% for file indexes and metadata.",
+      "instruction": "The exercise data needs to be archived for future training analysis. Based on how much data was generated each day (in terabytes) over the last 4 days of the exercise, estimate the total storage (in terabytes) needed to archive the full 14-day exercise, including an extra 30% for file indexes and metadata.",
       "hint": "The exercise ran for 14 days total, and you need to account for metadata and redundancy on top of the raw data.",
       "chartData": [2, 3, 5, 8],
-      "expected": 78,
+      "expected": 82,
       "tolerance": 20,
       "axisImpact": {
         "Cost-Conscious": 1,

--- a/src/scenarios/arc3-ch1.json
+++ b/src/scenarios/arc3-ch1.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc3-ch1.svg",
   "arc": 2,
   "chapter": 0,
+  "storyContext": "It starts with a flicker. Power readings from substations across Singapore spike and dip in a pattern that does not match any known equipment fault. Your team at DIS pulls up the grid monitoring feed and the room goes quiet. The fluctuations are too coordinated to be coincidence. Someone is inside the control systems. You have maybe hours before they escalate. The question is: how far have they already gone?",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",
@@ -23,9 +24,19 @@
       "axisImpact": { "Precision": 1, "Stability": 0.5 }
     },
     "data-scientist": {
+      "type": "numeric-input",
+      "title": "Estimate How Far It Has Spread",
+      "instruction": "The intrusion may have been active for days. Based on the percentage of devices showing anomalous network traffic over the last 4 monitoring windows, estimate how many of the 200 control system devices may already be compromised.",
+      "hint": "The percentage of affected devices is climbing. Project the next value in the trend, then apply that percentage to the total 200 devices.",
+      "chartData": [2, 5, 12, 22],
+      "expected": 70,
+      "tolerance": 20,
+      "axisImpact": { "Precision": 1, "Cost-Conscious": 0.5 }
+    },
+    "cloud-engineer": {
       "type": "binary-choice",
-      "title": "Identify the Threat",
-      "instruction": "The sensor readings show a pattern unlike anything in the history books. You have 30 minutes to classify the threat before leadership decides how to respond. What approach do you take?",
+      "title": "Deploy the Detection Toolkit",
+      "instruction": "The sensor readings show a pattern unlike anything in the history books. Your team needs to deploy the right detection tools to classify this threat before leadership decides how to respond. What approach do you deploy?",
       "hint": "Novel threats are tricky for automated tools trained only on known patterns. More methods combined tend to give more reliable answers than one fast method alone.",
       "options": [
         {
@@ -45,20 +56,10 @@
         },
         {
           "id": "ally-intel",
-          "label": "Share the anomaly signature with partner cybersecurity teams and ask if they've seen it. Could get an answer in 10 minutes but you'd be showing your hand to external parties.",
+          "label": "Share the anomaly signature with partner cybersecurity teams and ask if they have seen it. Could get an answer in 10 minutes but you would be showing your hand to external parties.",
           "axisImpact": { "Collaboration": 1, "Speed": 0.5, "Autonomy": -0.8 }
         }
       ]
-    },
-    "cloud-engineer": {
-      "type": "numeric-input",
-      "title": "Estimate How Far It Has Spread",
-      "instruction": "The intrusion may have been active for a while. Based on the suspicion scores for network traffic over the last 4 days (higher = more suspicious activity), estimate how many of the 200 control system devices may already be compromised.",
-      "hint": "The scores are rising fast. Look at where the trend is heading by the 4th day — that percentage of 200 gives you your estimate.",
-      "chartData": [3, 12, 35, 68],
-      "expected": 45,
-      "tolerance": 15,
-      "axisImpact": { "Precision": 1, "Cost-Conscious": 0.5 }
     }
   }
 }

--- a/src/scenarios/arc3-ch2.json
+++ b/src/scenarios/arc3-ch2.json
@@ -5,6 +5,7 @@
   "image": "/chapters/arc3-ch2.svg",
   "arc": 2,
   "chapter": 1,
+  "storyContext": "The lights went out across Jurong and Tuas at 3:14am. Within minutes, Tampines and Bedok followed. The attacker now controls 12 substations and your grid operations centre is in full crisis mode. Red phones are ringing. The Minister wants a situation report in 30 minutes. Every second the attacker stays connected, they can reach more of the grid.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",
@@ -24,7 +25,7 @@
         },
         {
           "id": "credential-rotation",
-          "label": "Emergency change of all system passwords across every device. If they're using stolen credentials, this locks them out — but changing passwords on live critical infrastructure mid-incident is risky.",
+          "label": "Emergency change of all system passwords across every device. If they're using stolen credentials, this locks them out, but changing passwords on live critical infrastructure mid-incident is risky.",
           "axisImpact": { "Precision": 1, "Stability": 0.3, "Speed": -0.3 }
         },
         {
@@ -70,7 +71,7 @@
         { "id": "zone-3", "label": "Monitored Access" },
         { "id": "zone-4", "label": "Normal Operations" }
       ],
-      "correctOrder": ["compromised-substations", "adjacent-substations", "control-centre", "clean-substations"],
+      "correctOrder": ["compromised-substations", "external-vendors", "adjacent-substations", "control-centre"],
       "axisImpact": { "Stability": 1, "Precision": 0.5 }
     }
   }

--- a/src/scenarios/arc3-ch3.json
+++ b/src/scenarios/arc3-ch3.json
@@ -5,18 +5,19 @@
   "image": "/chapters/arc3-ch3.svg",
   "arc": 2,
   "chapter": 2,
+  "storyContext": "The grid is secured, but 200,000 homes and businesses are still dark. Hospitals are running on backup generators with maybe four hours of fuel left. MRT stations are using emergency lighting. The Minister just went on national TV promising power by morning. One wrong move in the restoration sequence and you could overload the healthy grid, turning a partial blackout into a total one.",
   "subScenarios": {
     "software-engineer": {
       "type": "drag-drop",
       "variant": "order",
-      "title": "Run the Power Restoration Sequence",
-      "instruction": "Automated scripts will bring each station back online safely — but they must run in the right sequence or you risk overloading the healthy parts of the grid. Put the restoration steps in order.",
+      "title": "Program the Restoration Automation Sequence",
+      "instruction": "You are configuring the automation scripts that will bring each station back online. The scripts must run in the right sequence or you risk overloading the healthy parts of the grid. Arrange the restoration steps in the correct order so the automation runs safely.",
       "hint": "The whole grid depends on the main transmission lines. Hospitals and emergency services come before residential areas. Test before you go full-scale.",
       "items": [
         { "id": "verify-clean", "label": "Confirm every compromised station has been wiped and is definitely clean" },
         { "id": "restore-backbone", "label": "Bring back the main transmission stations that supply power to multiple zones" },
         { "id": "test-load", "label": "Run a test load to verify the backbone can handle the demand before connecting more" },
-        { "id": "restore-district", "label": "Restore district stations in priority order — hospitals and critical services first" },
+        { "id": "restore-district", "label": "Restore district stations in priority order: hospitals and critical services first" },
         { "id": "residential-last", "label": "Restore residential areas last, zone by zone based on grid capacity" }
       ],
       "correctOrder": ["verify-clean", "restore-backbone", "test-load", "restore-district", "residential-last"],
@@ -36,11 +37,11 @@
       "type": "binary-choice",
       "title": "Secure the Stations Before Restoring Power",
       "instruction": "The compromised control systems need to be fully secured before going back online. People are still without power, so time matters. What do you do?",
-      "hint": "Remember that 200,000 people are without power — but restoring a system that still has the attacker inside just hands them back control.",
+      "hint": "Remember that 200,000 people are without power, but restoring a system that still has the attacker inside just hands them back control.",
       "options": [
         {
           "id": "full-rebuild",
-          "label": "Complete rebuild from scratch — every compromised device gets a fresh install of everything. Takes 6 hours but you're 100% certain the attacker left no traces.",
+          "label": "Complete rebuild from scratch: every compromised device gets a fresh install of everything. Takes 6 hours but you're 100% certain the attacker left no traces.",
           "axisImpact": { "Stability": 1, "Precision": 0.8, "Speed": -0.8 }
         },
         {
@@ -56,7 +57,7 @@
         {
           "id": "hardware-swap",
           "label": "Replace the physical hardware entirely. The most expensive option and takes 12 hours, but eliminates any possibility of hidden software surviving at a deep level.",
-          "axisImpact": { "Stability": 0.8, "Precision": 1, "Cost-Conscious": -1 }
+          "axisImpact": { "Stability": 0.8, "Precision": 1, "Cost-Conscious": -0.8 }
         }
       ]
     }

--- a/src/scenarios/arc3-ch4.json
+++ b/src/scenarios/arc3-ch4.json
@@ -5,12 +5,13 @@
   "image": "/chapters/arc3-ch4.svg",
   "arc": 2,
   "chapter": 3,
+  "storyContext": "Power is back. Singapore woke up, went to work, and most people will never know how close it got. But the PM knows, and Parliament wants answers. Your team has one week to produce a brief that explains who did this, how they got in, and what stops it from ever happening again. The evidence you present will shape national cybersecurity policy for the next decade. Get it right.",
   "subScenarios": {
     "software-engineer": {
       "type": "binary-choice",
       "title": "Design the Permanent Defence",
       "instruction": "The attack exploited a gap between the power station control systems and the office IT network. Leadership wants a permanent technical solution. What do you propose?",
-      "hint": "The best long-term defence closes the gap without creating new operational problems — like making it impossible to manage systems remotely.",
+      "hint": "The best long-term defence closes the gap without creating new operational problems, including making it impossible to manage systems remotely.",
       "options": [
         {
           "id": "zero-trust-ot",
@@ -24,7 +25,7 @@
         },
         {
           "id": "air-gap",
-          "label": "Physically cut all internet connections to the critical power control systems forever. The ultimate defence but makes remote management impossible — every software update needs an engineer on-site.",
+          "label": "Physically cut all internet connections to the critical power control systems forever. The ultimate defence but makes remote management impossible: every software update needs an engineer on-site.",
           "axisImpact": { "Stability": 1, "Autonomy": 0.5, "Innovation": -0.8 }
         },
         {
@@ -37,15 +38,15 @@
     "data-scientist": {
       "type": "drag-drop",
       "variant": "order",
-      "title": "Build the Attribution Case",
+      "title": "Build the Data-Driven Attribution Case",
       "instruction": "Intelligence suggests a state-backed attacker, but the PM needs solid evidence before Parliament. Put these steps in the right order to build a credible case.",
       "hint": "In intelligence work, gather all the evidence before drawing conclusions. Build from the most concrete facts toward the broader picture, and always be honest about certainty.",
       "items": [
-        { "id": "ttps-match", "label": "Match the attacker's tools and methods against known threat actor profiles" },
-        { "id": "infrastructure-trace", "label": "Trace the attacker's control servers back through layers of disguise" },
-        { "id": "code-analysis", "label": "Analyse the malicious code for clues about who wrote it — language, style, timestamps" },
-        { "id": "timing-analysis", "label": "Check the timing of the attack against known working hours of suspected groups" },
-        { "id": "confidence-statement", "label": "Write a carefully worded conclusion that is honest about how certain the evidence actually is" }
+        { "id": "ttps-match", "label": "Apply pattern matching algorithms to map the attacker's tools and techniques against known threat group profiles" },
+        { "id": "infrastructure-trace", "label": "Conduct network flow analysis to trace the attacker's command servers through layers of obfuscation" },
+        { "id": "code-analysis", "label": "Run code similarity analysis on the malicious code to identify authorship by language patterns, style, and build timestamps" },
+        { "id": "timing-analysis", "label": "Apply statistical timing correlation to match the attack schedule against known working hour patterns of suspected groups" },
+        { "id": "confidence-statement", "label": "Synthesise all findings into a confidence-weighted attribution statement for Parliament" }
       ],
       "correctOrder": ["ttps-match", "infrastructure-trace", "code-analysis", "timing-analysis", "confidence-statement"],
       "axisImpact": { "Precision": 1, "Collaboration": 0.5 }


### PR DESCRIPTION
## Summary

This PR delivers a comprehensive content and correctness pass across all 12 scenario JSON files, plus a UI enhancement to surface narrative story context during gameplay.

### Phase 1 — storyContext (all 12 chapters)
- Added an immersive, present-tense narrative intro to every chapter
- Rendered in the game page (`src/app/game/[lobbyId]/page.tsx`) between the chapter image and scenario header as a dark card with italic text

### Phase 2 — Em-dash removal
- Replaced all `—` characters with natural alternatives (commas, colons, periods) across `arc3-ch2`, `arc3-ch3`, and `arc3-ch4`

### Phase 3 — Role swaps
- **arc1-ch2**: Swapped DS and CE sub-scenarios so the DS does data estimation and the CE does infrastructure investigation (was reversed)
- **arc3-ch1**: Swapped DS and CE sub-scenarios so the DS estimates spread from trend data and the CE deploys the detection toolkit

### Phase 4 — Numeric-input math fixes
- **arc1-ch4 DS** "Predict Viewer Drop-off": expected `480` → `530`, tolerance `80` → `60`; instruction reworded to ask for next-minute projection
- **arc2-ch4 CE** "Work Out How Much Storage You Need": expected `78` → `82`

### Phase 5 — Role reframes (title + instruction only)
- **arc2-ch1 SE**: "Design the Command Screen" → "Architect the Dashboard Components" (system architecture framing)
- **arc3-ch3 SE**: "Run the Power Restoration Sequence" → "Program the Restoration Automation Sequence" (automation scripting framing)
- **arc3-ch4 DS**: "Build the Attribution Case" → "Build the Data-Driven Attribution Case"; item labels rewritten to emphasise data methodology (pattern matching, network flow analysis, code similarity, statistical timing correlation)

### Phase 6 — Correctness and axis fixes
- **arc3-ch2 CE** correctOrder: contractor remote access (`external-vendors`) now isolates before adjacent substations — correct incident response priority
- **arc1-ch2 SE** `kill-features` Innovation penalty: `-0.8` → `-0.5`
- **arc3-ch3 CE** `hardware-swap` Cost-Conscious penalty: `-1` → `-0.8`

## Test plan
- [x] Start a lobby and play through at least one chapter per arc — verify storyContext renders correctly between chapter image and header, test using mobile phone and desktop https://dis-connect-git-develop-waahhaas-projects.vercel.app/
- [ ] Play arc1-ch4 as data-scientist — enter 530 and confirm it scores at or near 100%
- [ ] Play arc2-ch4 as cloud-engineer — enter 82 and confirm it scores correctly
- [ ] Play arc3-ch1 — confirm data-scientist sees the numeric spread estimate and cloud-engineer sees the binary detection toolkit choice
- [ ] Play arc1-ch2 — confirm data-scientist sees the numeric server shortfall estimate and cloud-engineer sees the drag-drop investigation
- [ ] Play arc3-ch2 as cloud-engineer — confirm correct order places `external-vendors` second
- [x] Check no em-dashes appear in any scenario text