### PR TITLE
fix: Vercel build lint error + ADMIN.md facilitator guide

### DIFF
--- a/src/scenarios/__tests__/groupScenarios.test.ts
+++ b/src/scenarios/__tests__/groupScenarios.test.ts
@@ -164,7 +164,7 @@ describe('wager multiplication math', () => {
         q.wagerOptions.forEach(wager => {
           q.options.forEach(opt => {
             const base = opt.axisImpact || {};
-            Object.entries(base).forEach(([axis, value]) => {
+            Object.values(base).forEach((value) => {
               const wagered = (value ?? 0) * wager;
               expect(wagered).toBeCloseTo((value ?? 0) * wager);
             });


### PR DESCRIPTION
## Summary

- Fix `@typescript-eslint/no-unused-vars` lint error in `groupScenarios.test.ts` that was breaking Vercel deployments (`Object.entries` → `Object.values` since the key was never used)
- Also includes earlier commits: scenario language simplification for student audience, vitest unit test suite, and `.claude` untrack

## Changes

- `src/scenarios/__tests__/groupScenarios.test.ts` — remove unused `axis` variable
- `ADMIN.md` — new facilitator guide covering game mechanics, scoring formula, all 12 chapters with correct answers and rationale, all 6 group questions with axis impact tables and recommended picks, and admin ops (leaderboard clear script, Firebase console reference)